### PR TITLE
dd: chaned one use

### DIFF
--- a/pages/common/dd.md
+++ b/pages/common/dd.md
@@ -7,9 +7,9 @@
 
 `dd status=progress if={{path/to/file.iso}} of=/dev/{{usb_drive}}`
 
-- Clone a drive to another drive with 4 MiB block and ignore error:
+- Clone a drive to another drive with 4 MiB block and flush writes before command terminates:
 
-`dd if=/dev/{{source_drive}} of=/dev/{{dest_drive}} bs={{4194304}} conv={{noerror}}`
+`dd if=/dev/{{source_drive}} of=/dev/{{dest_drive}} bs={{4M}} conv={{fsync}}`
 
 - Generate a file of 100 random bytes by using kernel random driver:
 


### PR DESCRIPTION
I think `fsync` is more useful that `noerror`
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 9.4
